### PR TITLE
Replace logback dependency with slf4j.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,9 +65,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>1.1.7</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.12</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Explicit logback version was causing dependency issues in downstream projects.