### PR TITLE
Async storage init on first store

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>spillway</artifactId>
-    <version>2.0.0-alpha.2</version>
+    <version>2.0.0-alpha.3</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/src/main/java/com/coveo/spillway/storage/InMemoryStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/InMemoryStorage.java
@@ -79,10 +79,7 @@ public class InMemoryStorage implements LimitUsageStorage {
   @Override
   public Map<LimitKey, Integer> debugCurrentLimitCounters() {
     removeExpiredEntries();
-    return map.values()
-        .stream()
-        .flatMap(m -> m.entrySet().stream())
-        .collect(Collectors.toMap(Map.Entry::getKey, kvp -> kvp.getValue().get()));
+    return getCurrentLimitCounters();
   }
 
   @Override
@@ -102,6 +99,14 @@ public class InMemoryStorage implements LimitUsageStorage {
     removeExpiredEntries();
   }
 
+  public Map<LimitKey, Integer> getCurrentLimitCounters()
+  {
+    return map.values()
+              .stream()
+              .flatMap(m -> m.entrySet().stream())
+              .collect(Collectors.toMap(Map.Entry::getKey, kvp -> kvp.getValue().get()));
+  }
+  
   @Override
   public Map<LimitKey, Integer> getCurrentLimitCounters(String resource) {
     removeExpiredEntries();

--- a/src/main/java/com/coveo/spillway/storage/utils/AddAndGetRequest.java
+++ b/src/main/java/com/coveo/spillway/storage/utils/AddAndGetRequest.java
@@ -121,6 +121,7 @@ public class AddAndGetRequest {
       this.resource = other.resource;
       this.limitName = other.limitName;
       this.property = other.property;
+      this.distributed = other.distributed;
       this.expiration = other.expiration;
       this.eventTimestamp = other.eventTimestamp;
       this.cost = other.cost;

--- a/src/main/java/com/coveo/spillway/storage/utils/CacheSynchronization.java
+++ b/src/main/java/com/coveo/spillway/storage/utils/CacheSynchronization.java
@@ -56,6 +56,8 @@ public class CacheSynchronization extends TimerTask {
 
   @Override
   public void run() {
+    logger.info("Synchronizing spillway storage cache.");
+
     cache.applyOnEach(
         instantEntry -> {
           try {


### PR DESCRIPTION
Problem was, on the first hit after spillway initialization, the in memory storage which act as a buffer had no values. Furthermore, synchronization with the distributed storage did not retrieve values for keys that weren't present in the in memory storage.

In our use case, we have short lived instances that are re-initializing spillway very frequently. Without this fix, we have a serious flickering in throttled requests.

The fix I made is the following:

Added a hook at limit insertion to check if the given key is known. 
- When it is known, move along as before.
- When it is not known, issue a zero cost insertion within the cache and trigger a sync

That mechanism has the drawback of looking up in the local cache keys on every request. However, when the key is present, no more processing is done.