### PR TITLE
ArrayIndexOutOfBoundsException on get limits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>spillway</artifactId>
-    <version>2.0.0-alpha.3</version>
+    <version>2.0.0-alpha.4</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/src/main/java/com/coveo/spillway/storage/RedisStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/RedisStorage.java
@@ -156,7 +156,10 @@ public class RedisStorage implements LimitUsageStorage {
                 keyComponents[3],
                 true,
                 Instant.parse(keyComponents[4]),
-                keyComponents.length == 6 ? Duration.parse(keyComponents[5]) : Duration.ZERO),
+                keyComponents.length == 6
+                    ? Duration.parse(keyComponents[5])
+                    : Duration
+                        .ZERO), // Version pre alpha.3 are not storing the expiration within the key so we fallback to 0
             value);
       }
     }

--- a/src/main/java/com/coveo/spillway/storage/RedisStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/RedisStorage.java
@@ -64,9 +64,10 @@ import redis.clients.jedis.Response;
 public class RedisStorage implements LimitUsageStorage {
   private static final Logger logger = LoggerFactory.getLogger(RedisStorage.class);
 
-  private static final String KEY_SEPARATOR = "|";
+  /*package*/ static final String DEFAULT_PREFIX = "spillway";
+  /*package*/ static final String KEY_SEPARATOR = "|";
+
   private static final String KEY_SEPARATOR_SUBSTITUTE = "_";
-  private static final String DEFAULT_PREFIX = "spillway";
   private static final String WILD_CARD_OPERATOR = "*";
 
   private final JedisPool jedisPool;
@@ -155,7 +156,7 @@ public class RedisStorage implements LimitUsageStorage {
                 keyComponents[3],
                 true,
                 Instant.parse(keyComponents[4]),
-                Duration.parse(keyComponents[5])),
+                keyComponents.length == 6 ? Duration.parse(keyComponents[5]) : Duration.ZERO),
             value);
       }
     }


### PR DESCRIPTION
Fixed bug where pre-upgrade remote limit keys could lead to ArrayIndexOutOfBoundsException until they expire, since they do not contain expiration.

The only path affected by this fix is the CacheSynchronization.init method I just added in alpha.3. 
It will have the effect of expiring pre-upgrade limits on init.

