### PR TITLE
Add null check in getLimits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.coveo</groupId>
     <artifactId>spillway</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.1</version>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>

--- a/src/main/java/com/coveo/spillway/storage/RedisStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/RedisStorage.java
@@ -146,7 +146,7 @@ public class RedisStorage implements LimitUsageStorage {
       Set<String> keys = jedis.keys(keyPattern);
       for (String key : keys) {
         String valueAsString = jedis.get(key);
-        if (valueAsString != null && !valueAsString.equals("")) {
+        if (StringUtils.isNotEmpty(valueAsString)) {
           int value = Integer.parseInt(valueAsString);
 
           String[] keyComponents = StringUtils.split(key, KEY_SEPARATOR);

--- a/src/main/java/com/coveo/spillway/storage/RedisStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/RedisStorage.java
@@ -145,22 +145,25 @@ public class RedisStorage implements LimitUsageStorage {
     try (Jedis jedis = jedisPool.getResource()) {
       Set<String> keys = jedis.keys(keyPattern);
       for (String key : keys) {
-        int value = Integer.parseInt(jedis.get(key));
+        String valueAsString = jedis.get(key);
+        if (valueAsString != null && !valueAsString.equals("")) {
+          int value = Integer.parseInt(valueAsString);
 
-        String[] keyComponents = StringUtils.split(key, KEY_SEPARATOR);
+          String[] keyComponents = StringUtils.split(key, KEY_SEPARATOR);
 
-        counters.put(
-            new LimitKey(
-                keyComponents[1],
-                keyComponents[2],
-                keyComponents[3],
-                true,
-                Instant.parse(keyComponents[4]),
-                keyComponents.length == 6
-                    ? Duration.parse(keyComponents[5])
-                    : Duration
-                        .ZERO), // Version pre alpha.3 are not storing the expiration within the key so we fallback to 0
-            value);
+          counters.put(
+              new LimitKey(
+                  keyComponents[1],
+                  keyComponents[2],
+                  keyComponents[3],
+                  true,
+                  Instant.parse(keyComponents[4]),
+                  keyComponents.length == 6
+                      ? Duration.parse(keyComponents[5])
+                      : Duration
+                          .ZERO), // Version pre alpha.3 are not storing the expiration within the key so we fallback to 0
+              value);
+        }
       }
     }
     return Collections.unmodifiableMap(counters);

--- a/src/main/java/com/coveo/spillway/storage/RedisStorage.java
+++ b/src/main/java/com/coveo/spillway/storage/RedisStorage.java
@@ -163,6 +163,8 @@ public class RedisStorage implements LimitUsageStorage {
                       : Duration
                           .ZERO), // Version pre alpha.3 are not storing the expiration within the key so we fallback to 0
               value);
+        } else {
+          logger.info("Key '{}' has no value and will not be included in counters", key);
         }
       }
     }


### PR DESCRIPTION
add a null check when fetching limits as race condition could happen if the entry expires after calling keys() but before calling get(key) on a specific key

I also want add logging, but was wondering what level it should be. I guess trace or debug?